### PR TITLE
Improve DXF reader error handling

### DIFF
--- a/SimpleDXF/SimpleDXF.cs
+++ b/SimpleDXF/SimpleDXF.cs
@@ -46,9 +46,10 @@ namespace SimpleDXF {
             CultureInfo cultureInfo = CultureInfo.CurrentCulture;
             Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
 
-            if (File.Exists(dxfFile)) {
-                dxfReader = new StreamReader(dxfFile);
-            }
+            if (!File.Exists(dxfFile))
+                throw new FileNotFoundException("DXF file not found", dxfFile);
+
+            dxfReader = new StreamReader(dxfFile);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- throw a `FileNotFoundException` from `Document` constructor when the file does not exist

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850d6c6e1d48320a0ea4594def85715