### PR TITLE
Fix ACItoARGB comment

### DIFF
--- a/SimpleDXF/SimpleDXF.cs
+++ b/SimpleDXF/SimpleDXF.cs
@@ -1011,7 +1011,7 @@ namespace SimpleDXF {
         /// <summary>
         /// Convert any AciColor value to ARGB
         /// </summary>
-        /// <param name="ACIColor">The AciColor index, from 0 to 2055</param>
+        /// <param name="ACIColor">The AciColor index, from 0 to 255</param>
         /// <returns>32bit unsigned integer with the color in ARGB format</returns>
         public static uint ACItoARGB(byte AciColor) {
             if (AciColor > 255 || AciColor < 0)


### PR DESCRIPTION
## Summary
- correct parameter comment for `ACItoARGB`

## Testing
- `dotnet build SimpleDXF/SimpleDXF.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d9a0c95083209f73b7c2d3b8affa