### PR TITLE
Fix line counter

### DIFF
--- a/SimpleDXF/SimpleDXF.cs
+++ b/SimpleDXF/SimpleDXF.cs
@@ -154,6 +154,7 @@ namespace SimpleDXF {
                 throw new Exception("Invalid code (" + line + ") at line " + this.dxfLinesRead);
             } else {
                 value = dxfReader.ReadLine();
+                dxfLinesRead++;
                 return new CodePair(code, value);
             }
         }


### PR DESCRIPTION
## Summary
- update line counter when reading DXF value lines

## Testing
- `dotnet build SimpleDXF.sln` *(fails: command not found)*
- `msbuild SimpleDXF.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d9fc168c8320bb8b30debe8fc3b1